### PR TITLE
Fixes union resources not always being described

### DIFF
--- a/src/config/resting.php
+++ b/src/config/resting.php
@@ -15,5 +15,6 @@ return [
                 'description' => 'Local'
             ]
         ],
+        'resources' => [],
     ],
 ];


### PR DESCRIPTION
Adding config option to make sure resources that aren't picked up automatically can be described by noting them in the config file